### PR TITLE
Add CI tests and sanitize generated content

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: pytest

--- a/Files/data_pipeline.py
+++ b/Files/data_pipeline.py
@@ -326,11 +326,9 @@ class PillarPageGenerator:
 
         # Insert JSON data (replace placeholder block with sanitized JSON)
         json_string = json.dumps(json_data, ensure_ascii=False, indent=2)
-        page_content = re.sub(
-            r"const DATA = \[.*?\];",
-            f"const DATA = {json_string};",
-            page_content,
-            flags=re.DOTALL,
+        page_content = page_content.replace(
+            "/* DATA_PLACEHOLDER */",
+            f"const DATA = {json_string};"
         )
 
         # Update schema.org

--- a/Files/data_pipeline.py
+++ b/Files/data_pipeline.py
@@ -324,7 +324,7 @@ class PillarPageGenerator:
             "{{CANONICAL_URL}}", self._sanitize_text(canonical_url)
         )
 
-        # Insert JSON data (replace placeholder block with sanitized JSON)
+        # Insert JSON data (already sanitized) into template
         json_string = json.dumps(json_data, ensure_ascii=False, indent=2)
         page_content = page_content.replace(
             "/* DATA_PLACEHOLDER */",

--- a/Files/data_pipeline.py
+++ b/Files/data_pipeline.py
@@ -4,7 +4,7 @@ import html
 import re
 import time
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List
 
 import requests
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Nach Änderungen:
 python3 generate_ai_optimized_site.py
 ```
 
+## 🧪 Tests & Qualitätssicherung
+
+- Test-Suite lokal ausführen: `pytest`
+- GitHub Actions Workflow `tests.yml` führt die Tests bei jedem Push/PR automatisch aus.
+- Alle eingehenden Standortdaten werden vor dem Rendering geescaped, um die Authentizität der Inhalte zu sichern und Script-Injektionen zu verhindern.
+
 ## 🚀 Deployment
 
 ### Automatisches Deployment (GitHub Actions)

--- a/generate_ai_optimized_site.py
+++ b/generate_ai_optimized_site.py
@@ -4,10 +4,11 @@ Generate AI-SEO optimized Babelsberg site
 Optimized for ChatGPT, Perplexity, Claude, and other AI search engines
 """
 
-import json
 import csv
-from pathlib import Path
+import html
+import json
 from datetime import datetime
+from pathlib import Path
 
 # Configuration - AI SEO optimized
 config = {
@@ -140,17 +141,22 @@ def prepare_location_data(locations):
     """Prepare locations for JavaScript with AI-friendly structure"""
     js_data = []
     for loc in locations:
+        def sanitize(value):
+            if value is None:
+                return ""
+            return html.escape(str(value))
+
         item = {
-            "name": loc['name'],
-            "address": loc.get('address', ''),
-            "city": loc['city'],
+            "name": sanitize(loc['name']),
+            "address": sanitize(loc.get('address', '')),
+            "city": sanitize(loc['city']),
             "rating": float(loc['rating']) if loc.get('rating') else 0,
             "review_count": int(loc.get('review_count', 0)),
-            "description": loc.get('description_de', ''),
-            "tags": loc.get('tags', ''),
-            "image": loc.get('main_image', ''),
-            "opening_hours": loc.get('opening_hours', ''),
-            "website": loc.get('website', ''),
+            "description": sanitize(loc.get('description_de', '')),
+            "tags": sanitize(loc.get('tags', '')),
+            "image": sanitize(loc.get('main_image', '')),
+            "opening_hours": sanitize(loc.get('opening_hours', '')),
+            "website": sanitize(loc.get('website', '')),
             "latitude": float(loc['latitude']),
             "longitude": float(loc['longitude']),
             "feature_shade": convert_bool(loc.get('feature_shade')),

--- a/tests/test_sanitization.py
+++ b/tests/test_sanitization.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
-
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 FILES_DIR = PROJECT_ROOT / "Files"
 

--- a/tests/test_sanitization.py
+++ b/tests/test_sanitization.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+FILES_DIR = PROJECT_ROOT / "Files"
+
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+if str(FILES_DIR) not in sys.path:
+    sys.path.insert(0, str(FILES_DIR))
+
+from data_pipeline import LocationData, PillarPageGenerator
+from generate_ai_optimized_site import prepare_location_data
+
+
+def test_prepare_location_data_sanitizes_script_payload() -> None:
+    malicious_location = {
+        "name": "Park</script><script>alert('xss')</script>",
+        "address": "<b>Street 1</b>",
+        "city": "Berlin",
+        "rating": "4.2",
+        "review_count": "10",
+        "description_de": "Toller Ort <script>evil()</script>",
+        "tags": "familienfreundlich",
+        "main_image": "https://example.com/image.png",
+        "opening_hours": "Immer",
+        "website": "https://example.com",
+        "latitude": "52.52",
+        "longitude": "13.4",
+        "feature_shade": "TRUE",
+        "feature_water": "FALSE",
+        "feature_benches": "TRUE",
+        "feature_parking": "TRUE",
+        "feature_toilets": "TRUE",
+        "feature_wheelchair_accessible": "FALSE",
+        "feature_kids_friendly": "FALSE",
+        "feature_dogs_allowed": "FALSE",
+        "feature_fee": "FALSE",
+        "feature_seasonal": "FALSE",
+        "feature_fkk": "FALSE",
+        "feature_restaurant": "FALSE",
+        "feature_photography": "FALSE",
+        "feature_historic": "FALSE",
+    }
+
+    sanitized = prepare_location_data([malicious_location])[0]
+
+    assert "<script" not in sanitized["name"].lower()
+    assert "&lt;/script&gt;" in sanitized["name"]
+    assert sanitized["description"].startswith("Toller Ort")
+
+
+def test_pillar_page_generator_escapes_template_values(tmp_path: Path) -> None:
+    template = tmp_path / "template.html"
+    template.write_text(
+        """
+        <html>
+        <head></head>
+        <body>
+        <h1>{{CITY}} - {{CATEGORY}}</h1>
+        <script>const DATA = [
+        ];</script>
+        <a href="{{CANONICAL_URL}}">link</a>
+        </body>
+        </html>
+        """,
+        encoding="utf-8",
+    )
+
+    generator = PillarPageGenerator(str(template))
+    output_path = tmp_path / "output.html"
+
+    generator.generate_page(
+        data=[
+            LocationData(
+                id="loc-1",
+                name="Test<script>alert('bad')</script>",
+                street="<b>Main</b> Street",
+                city="Berlin",
+                region="Berlin",
+                country="DE",
+                postcode="10115",
+                latitude=52.5,
+                longitude=13.4,
+                url="https://example.com/<script>hack</script>",
+                phone="<script>call()</script>",
+                email="user@example.com",
+                opening_hours="Täglich",
+                rating=4.8,
+                review_count=12,
+                feature_shade=True,
+                feature_benches=True,
+                feature_water=False,
+                feature_parking=True,
+                feature_toilets=False,
+                feature_wheelchair_accessible=False,
+                feature_kids_friendly=False,
+                feature_dogs_allowed=False,
+                feature_fee=False,
+                feature_seasonal=False,
+            )
+        ],
+        city="Berlin<script>alert('city')</script>",
+        category="Parks<script>bad()</script>",
+        output_path=str(output_path),
+        canonical_url="https://example.com/<script>malicious</script>",
+    )
+
+    content = output_path.read_text(encoding="utf-8")
+
+    assert "<script>alert('city')</script>" not in content
+    assert "Parks&lt;script&gt;bad()&lt;/script&gt;" in content
+    assert "<script>hack</script>" not in content


### PR DESCRIPTION
## Summary
- escape location and template inputs in the generators to keep rendered pages authentic and free from script injection
- add regression tests covering sanitization for the CSV pipeline and pillar page generation
- introduce a GitHub Actions workflow to run pytest on pushes and pull requests and document the testing process

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6934d2a0d35083228f888ee630ca6eff)